### PR TITLE
Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750776420,
-        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
+        "lastModified": 1751637120,
+        "narHash": "sha256-xVNy/XopSfIG9c46nRmPaKfH1Gn/56vQ8++xWA8itO4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
+        "rev": "5c724ed1388e53cc231ed98330a60eb2f7be4be3",
         "type": "github"
       },
       "original": {

--- a/package.nix
+++ b/package.nix
@@ -4,6 +4,12 @@ let
   version = "2.0.2";
 
   self = pkgs.python312Packages.buildPythonApplication {
+    pyproject = true;
+
+    build-system = [
+      pkgs.python312Packages.setuptools
+    ];
+
     inherit pname version;
     src = pkgs.fetchFromGitLab {
       owner = "oscar.krause";


### PR DESCRIPTION
Updates the flake.lock and also fixes the following error:

fastapi-dls-2.0.2 does not configure a `format`. To build with setuptools as before, set `pyproject = true` and `build-system = [ setuptools ]`.